### PR TITLE
Remove expected nodes check

### DIFF
--- a/elasticache.go
+++ b/elasticache.go
@@ -128,15 +128,11 @@ func clusterNodes() (NodeList, error) {
 	}
 	nodes := []Node{}
 
-	for i, line := range *nodeInfo {
+	for _, line := range *nodeInfo {
 		if strings.Contains(line, "|") {
 			nodeStrings := strings.Split(line, NODE_SEPARATOR)
-			expectedNodes, err := strconv.Atoi((*nodeInfo)[i-1])
 			if err != nil {
 				return nil, errors.New("Bad node count conversion: " + err.Error())
-			}
-			if len(nodeStrings) != expectedNodes {
-				return nil, errors.New(fmt.Sprintf("Mismatched node list found, saw %d nodes but expected %d", len(nodeStrings), expectedNodes))
 			}
 			for _, ns := range nodeStrings {
 				n, err := parseNodeLine(ns)


### PR DESCRIPTION
The output format of the `config get cluster` for Elasticache is not the number of nodes but is the amount of times the cluster has been updated.

> http://docs.aws.amazon.com/AmazonElastiCache/latest/UserGuide/AutoDiscovery.AddingToYourClientLibrary.html#AutoDiscovery.AddingToYourClientLibrary.OutputFormat

```
CONFIG cluster 0 147\r\n
12\n
myCluster.pc4ldq.0001.use1.cache.amazonaws.com|10.82.235.120|11211 myCluster.pc4ldq.0002.use1.cache.amazonaws.com|10.80.249.27|11211\n\r\n 
END\r\n
```

> The second line indicates that the configuration information has been modified twelve times so far.